### PR TITLE
Adding proper cleanup of textures.

### DIFF
--- a/layers-samples/cube-layer.html
+++ b/layers-samples/cube-layer.html
@@ -123,6 +123,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       // with the XRDisplay we're presenting to.
       gl = createWebGLContext({ xrCompatible: true, webgl2: true, });
       document.body.appendChild(gl.canvas);
+      gl.clearColor(0.0, 0, 0, 0.0);
 
       function onResize() {
         gl.canvas.width = gl.canvas.clientWidth * window.devicePixelRatio;
@@ -286,9 +287,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
       if (pose) {
         gl.bindFramebuffer(gl.FRAMEBUFFER, xrFramebuffer);
-        // We need to invalidate the color (and depth, just in case) here to avoid
-        // loading from the previously bound color texture. It will save some GPU time.
-        gl.invalidateFramebuffer(gl.FRAMEBUFFER, [gl.COLOR_ATTACHMENT0, gl.DEPTH_ATTACHMENT]);
 
         // This is a different rendering pattern than the previous samples
         // used, but it should be more efficent. It's very common for apps
@@ -348,6 +346,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           gl.bindFramebuffer(gl.FRAMEBUFFER, xrFramebuffer);
           gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, glLayer.colorTexture, 0);
           gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, glLayer.depthStencilTexture, 0);
+
+          gl.enable(gl.SCISSOR_TEST);
+          gl.scissor(viewport.x, viewport.y, viewport.width, viewport.height);
+          gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+          gl.disable(gl.SCISSOR_TEST);
 
           // Gather all the values needed for one view and push it into the
           // array of views to be drawn. WebXRView is a utility class that

--- a/layers-samples/cyld-layer.html
+++ b/layers-samples/cyld-layer.html
@@ -122,6 +122,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       // with the XRDisplay we're presenting to.
       gl = createWebGLContext({ xrCompatible: true, webgl2: true, });
       document.body.appendChild(gl.canvas);
+      gl.clearColor(0.0, 0, 0, 0.0);
 
       function onResize() {
         gl.canvas.width = gl.canvas.clientWidth * window.devicePixelRatio;
@@ -222,9 +223,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
       if (pose) {
         gl.bindFramebuffer(gl.FRAMEBUFFER, xrFramebuffer);
-        // We need to invalidate the color (and depth, just in case) here to avoid
-        // loading from the previously bound color texture. It will save some GPU time.
-        gl.invalidateFramebuffer(gl.FRAMEBUFFER, [gl.COLOR_ATTACHMENT0, gl.DEPTH_ATTACHMENT]);
 
         // This is a different rendering pattern than the previous samples
         // used, but it should be more efficent. It's very common for apps
@@ -284,6 +282,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           gl.bindFramebuffer(gl.FRAMEBUFFER, xrFramebuffer);
           gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, glLayer.colorTexture, 0);
           gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, glLayer.depthStencilTexture, 0);
+
+          gl.enable(gl.SCISSOR_TEST);
+          gl.scissor(viewport.x, viewport.y, viewport.width, viewport.height);
+          gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+          gl.disable(gl.SCISSOR_TEST);
 
           // Gather all the values needed for one view and push it into the
           // array of views to be drawn. WebXRView is a utility class that

--- a/layers-samples/eqrt-layer.html
+++ b/layers-samples/eqrt-layer.html
@@ -134,6 +134,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       // with the XRDisplay we're presenting to.
       gl = createWebGLContext({ xrCompatible: true, webgl2: true, });
       document.body.appendChild(gl.canvas);
+      gl.clearColor(0.0, 0, 0, 0.0);
 
       function onResize() {
         gl.canvas.width = gl.canvas.clientWidth * window.devicePixelRatio;
@@ -235,9 +236,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
       if (pose) {
         gl.bindFramebuffer(gl.FRAMEBUFFER, xrFramebuffer);
-        // We need to invalidate the color (and depth, just in case) here to avoid
-        // loading from the previously bound color texture. It will save some GPU time.
-        gl.invalidateFramebuffer(gl.FRAMEBUFFER, [gl.COLOR_ATTACHMENT0, gl.DEPTH_ATTACHMENT]);
 
         // This is a different rendering pattern than the previous samples
         // used, but it should be more efficent. It's very common for apps
@@ -297,6 +295,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           gl.bindFramebuffer(gl.FRAMEBUFFER, xrFramebuffer);
           gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, glLayer.colorTexture, 0);
           gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, glLayer.depthStencilTexture, 0);
+
+          gl.enable(gl.SCISSOR_TEST);
+          gl.scissor(viewport.x, viewport.y, viewport.width, viewport.height);
+          gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+          gl.disable(gl.SCISSOR_TEST);
 
           // Gather all the values needed for one view and push it into the
           // array of views to be drawn. WebXRView is a utility class that

--- a/layers-samples/eqrt-video.html
+++ b/layers-samples/eqrt-video.html
@@ -151,6 +151,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       // with the XRDisplay we're presenting to.
       gl = createWebGLContext({ xrCompatible: true, webgl2: true, });
       document.body.appendChild(gl.canvas);
+      gl.clearColor(0.0, 0, 0, 0.0);
 
       function onResize() {
         gl.canvas.width = gl.canvas.clientWidth * window.devicePixelRatio;
@@ -322,6 +323,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           gl.bindFramebuffer(gl.FRAMEBUFFER, xrFramebuffer);
           gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, glLayer.colorTexture, 0);
           gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, glLayer.depthStencilTexture, 0);
+
+          gl.enable(gl.SCISSOR_TEST);
+          gl.scissor(viewport.x, viewport.y, viewport.width, viewport.height);
+          gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+          gl.disable(gl.SCISSOR_TEST);
 
           // Gather all the values needed for one view and push it into the
           // array of views to be drawn. WebXRView is a utility class that

--- a/layers-samples/proj-layer.html
+++ b/layers-samples/proj-layer.html
@@ -108,6 +108,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       // with the XRDisplay we're presenting to.
       gl = createWebGLContext({ xrCompatible: true, webgl2: true, });
       document.body.appendChild(gl.canvas);
+      gl.clearColor(0.8, 0.8, 0.8, 1);
 
       function onResize() {
         gl.canvas.width = gl.canvas.clientWidth * window.devicePixelRatio;
@@ -167,9 +168,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
       if (pose) {
         gl.bindFramebuffer(gl.FRAMEBUFFER, xrFramebuffer);
-        // We need to invalidate the color (and depth, just in case) here to avoid
-        // loading from the previously bound color texture. It will save some GPU time.
-        gl.invalidateFramebuffer(gl.FRAMEBUFFER, [gl.COLOR_ATTACHMENT0, gl.DEPTH_ATTACHMENT]);
 
         // This is a different rendering pattern than the previous samples
         // used, but it should be more efficent. It's very common for apps
@@ -230,9 +228,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, glLayer.colorTexture, 0);
           gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, glLayer.depthStencilTexture, 0);
 
+          gl.enable(gl.SCISSOR_TEST);
+          gl.scissor(viewport.x, viewport.y, viewport.width, viewport.height);
+          gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
           gl.disable(gl.SCISSOR_TEST);
-          gl.clearColor(0.8, 0.8, 0.8, 1);
-          gl.clear(gl.COLOR_BUFFER_BIT);
 
           // Gather all the values needed for one view and push it into the
           // array of views to be drawn. WebXRView is a utility class that

--- a/layers-samples/proj-multiview.html
+++ b/layers-samples/proj-multiview.html
@@ -141,7 +141,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
       // Set up a non-black clear color so that we can see if something renders wrong.
       gl.clearColor(0.1, 0.2, 0.3, 1.0);
-
     }
 
     function onRequestSession() {
@@ -317,6 +316,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 mv_ext.framebufferTextureMultisampleMultiviewOVR(gl.DRAW_FRAMEBUFFER, gl.DEPTH_ATTACHMENT, depthStencilTex, 0, samples, 0, 2);
               console.log("Fbo attachment numviews = " + gl.getFramebufferAttachmentParameter(gl.DRAW_FRAMEBUFFER, gl.DEPTH_ATTACHMENT, mv_ext.FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR));
               console.log("Fbo base view index = " + gl.getFramebufferAttachmentParameter(gl.DRAW_FRAMEBUFFER, gl.DEPTH_ATTACHMENT, mv_ext.FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR));
+
+              gl.disable(gl.SCISSOR_TEST);
+              gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
             }
           } else {
             viewport = glLayer.getViewport(view);

--- a/layers-samples/quad-ab-test.html
+++ b/layers-samples/quad-ab-test.html
@@ -262,9 +262,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
       if (pose) {
         gl.bindFramebuffer(gl.FRAMEBUFFER, xrFramebuffer);
-        // We need to invalidate the color (and depth, just in case) here to avoid
-        // loading from the previously bound color texture. It will save some GPU time.
-        gl.invalidateFramebuffer(gl.FRAMEBUFFER, [gl.COLOR_ATTACHMENT0, gl.DEPTH_ATTACHMENT]);
 
         // This is a different rendering pattern than the previous samples
         // used, but it should be more efficent. It's very common for apps
@@ -324,6 +321,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           gl.bindFramebuffer(gl.FRAMEBUFFER, xrFramebuffer);
           gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, glLayer.colorTexture, 0);
           gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, glLayer.depthStencilTexture, 0);
+
+          gl.enable(gl.SCISSOR_TEST);
+          gl.scissor(viewport.x, viewport.y, viewport.width, viewport.height);
+          gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+          gl.disable(gl.SCISSOR_TEST);
 
           // Gather all the values needed for one view and push it into the
           // array of views to be drawn. WebXRView is a utility class that

--- a/layers-samples/quad-layer.html
+++ b/layers-samples/quad-layer.html
@@ -124,6 +124,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       // with the XRDisplay we're presenting to.
       gl = createWebGLContext({ xrCompatible: true, webgl2: true, });
       document.body.appendChild(gl.canvas);
+      gl.clearColor(0.0, 0, 0, 0.0);
 
       function onResize() {
         gl.canvas.width = gl.canvas.clientWidth * window.devicePixelRatio;
@@ -226,9 +227,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
       if (pose) {
         gl.bindFramebuffer(gl.FRAMEBUFFER, xrFramebuffer);
-        // We need to invalidate the color (and depth, just in case) here to avoid
-        // loading from the previously bound color texture. It will save some GPU time.
-        gl.invalidateFramebuffer(gl.FRAMEBUFFER, [gl.COLOR_ATTACHMENT0, gl.DEPTH_ATTACHMENT]);
 
         // This is a different rendering pattern than the previous samples
         // used, but it should be more efficent. It's very common for apps
@@ -288,6 +286,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           gl.bindFramebuffer(gl.FRAMEBUFFER, xrFramebuffer);
           gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, glLayer.colorTexture, 0);
           gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, glLayer.depthStencilTexture, 0);
+
+          gl.enable(gl.SCISSOR_TEST);
+          gl.scissor(viewport.x, viewport.y, viewport.width, viewport.height);
+          gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+          gl.disable(gl.SCISSOR_TEST);
 
           // Gather all the values needed for one view and push it into the
           // array of views to be drawn. WebXRView is a utility class that

--- a/layers-samples/quad-select.html
+++ b/layers-samples/quad-select.html
@@ -279,9 +279,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
       if (pose) {
         gl.bindFramebuffer(gl.FRAMEBUFFER, xrFramebuffer);
-        // We need to invalidate the color (and depth, just in case) here to avoid
-        // loading from the previously bound color texture. It will save some GPU time.
-        gl.invalidateFramebuffer(gl.FRAMEBUFFER, [gl.COLOR_ATTACHMENT0, gl.DEPTH_ATTACHMENT]);
 
         // This is a different rendering pattern than the previous samples
         // used, but it should be more efficent. It's very common for apps
@@ -360,6 +357,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           gl.bindFramebuffer(gl.FRAMEBUFFER, xrFramebuffer);
           gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, glLayer.colorTexture, 0);
           gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, glLayer.depthStencilTexture, 0);
+
+          gl.enable(gl.SCISSOR_TEST);
+          gl.scissor(viewport.x, viewport.y, viewport.width, viewport.height);
+          gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+          gl.disable(gl.SCISSOR_TEST);
 
           // Gather all the values needed for one view and push it into the
           // array of views to be drawn. WebXRView is a utility class that


### PR DESCRIPTION
After D25543281 lands the layers sample will be broken since they do not have proper calls to gl.clear. The reason why it worked before is the call to gl.invalidateFramebuffer, which is now going to be useless.

A bit more details. Now, the textures going to be invalidated and detached from the framebuffer at the end of rAF. User's code must get the texture and attach to a FBO each frame (each frame when the content is going to be updated). Thus the previous call to gl.invalidateFramebuffer at the beginning of the frame has no effect since there is no color attachment yet. The invalidateFramebuffer caused the clear to happen automatically, but since it has no effect anymore we need to add proper gl.clear calls.